### PR TITLE
Dependency update for Bevy 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,13 +28,13 @@ encryption = ["aes", "block-modes"]
 # compression = ["brotli"]
 
 [workspace.dependencies]
-bevy = { version = "0.10", default-features = false }
+bevy = { version = "0.11", default-features = false }
 
 [dependencies]
 bevy = { workspace = true, default-features = false, features = ["bevy_asset"] }
 
 anyhow = "1"
-bs58 = "0.4"
+bs58 = "0.5"
 cfg-if = "1"
 tar = "0.4.38"
 tracing = "0.1"

--- a/src/plugin/bundled_asset_io.rs
+++ b/src/plugin/bundled_asset_io.rs
@@ -12,6 +12,7 @@ use bevy::{
     asset::{AssetIo, AssetIoError},
     utils::BoxedFuture,
 };
+use bevy::asset::ChangeWatcher;
 use tar::Archive;
 
 use super::path_info::ArchivePathInfo;
@@ -136,7 +137,7 @@ impl AssetIo for BundledAssetIo {
         Ok(())
     }
 
-    fn watch_for_changes(&self) -> Result<(), AssetIoError> {
+    fn watch_for_changes(&self, _watcher: &ChangeWatcher) -> Result<(), AssetIoError> {
         Ok(())
     }
 


### PR DESCRIPTION
Still needs a fix for the deprecated crypto libs in use, but I've got no experience in cryptography